### PR TITLE
My Gallery Bug Fix

### DIFF
--- a/src/Components/MainGallery.tsx
+++ b/src/Components/MainGallery.tsx
@@ -4,14 +4,11 @@ import ArtCard from './ArtCard'
 import { useEffect, useState } from 'react'
 import { Record } from '../Utility/Types'
 import { useFavorites } from './Favorites'
-import { FavoriteRecord } from '../Utility/Types'
 import { fetchArtRecords } from './ApiCalls'
 
-
-interface MainGalleryProps {
-    records: Record[];
-    // handleFavorite: (id: number) => void;
-}
+// interface MainGalleryProps {
+//     records: Record[];
+// }
 
 const MainGallery: React.FC = () => {
     const [allRecords, setAllRecords] = useState<Record[]>([]);
@@ -21,9 +18,7 @@ const MainGallery: React.FC = () => {
     function handleFavorite(record: Record) {
         const isAlreadyFavorited = favoriteRecords.some(favoriteRecord => favoriteRecord.id === record.id)
 
-        if (isAlreadyFavorited) {
-            return setFavoriteRecords(favoriteRecords.filter(favoriteRecord => favoriteRecord.id !== record.id))
-        } else {
+        if (!isAlreadyFavorited) {
             setFavoriteRecords([...favoriteRecords, record])
         }
     }
@@ -39,7 +34,6 @@ const MainGallery: React.FC = () => {
         }
         loadRecords()
     }, [])
-
 
     const artCards = allRecords.map(record => {
         return (


### PR DESCRIPTION
**What does this PR do**
- Fixes bug that occurred when a user tried to favorite the same artifact twice. Previously, if a user tried to favorite the same artifact twice, the artifact was deleted from My Gallery. This bug has been fixed. If a user tries to favorite the same artifact twice, the artifact appears once in My Gallery. 
- Removes unused import and extra space. 

**How Should the Reviewer Manually Test This?**
 - [ ] Navigate to Main Gallery, use the red "+" to add an artifact to My Gallery. Next, navigate to My Gallery to ensure the artifact has been added. Navigate to Main Page and then back to My Gallery, to confirm the favorited artifact remains in My Gallery.